### PR TITLE
Install MSBuild and rules files with VSIX

### DIFF
--- a/samples/WindowsScript/WindowsScript/WindowsScript.ProjectTemplate/WindowsScript.wsproj
+++ b/samples/WindowsScript/WindowsScript/WindowsScript.ProjectTemplate/WindowsScript.wsproj
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
-    <CustomProjectExtensionsPath>$(LocalAppData)\CustomProjectSystems\WindowsScript\</CustomProjectExtensionsPath>
+    <!-- NOTE: You might want to remove the first property definition (that looks for the file in the LocalAppData folder)
+         for your production template. It's here just to make testing/debugging changes to the project system as easy as
+         building the project and running the experimental instance. -->
+    <CustomProjectExtensionsPath Condition="Exists('$(LocalAppData)\CustomProjectSystems\WindowsScript\WindowsScript.props')">$(LocalAppData)\CustomProjectSystems\WindowsScript\</CustomProjectExtensionsPath>
+    <CustomProjectExtensionsPath Condition="'$(CustomProjectExtensionsPath)' == ''">$(MSBuildExtensionsPath)\CustomProjectSystems\WindowsScript\</CustomProjectExtensionsPath>
   </PropertyGroup>
 
   <Import Project="$(CustomProjectExtensionsPath)WindowsScript.props" />

--- a/samples/WindowsScript/WindowsScript/WindowsScript.ProjectType/WindowsScript.ProjectType.csproj
+++ b/samples/WindowsScript/WindowsScript/WindowsScript.ProjectType/WindowsScript.ProjectType.csproj
@@ -244,11 +244,31 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- TODO: This copies the build authoring to a well-known location so that on the machine this project builds on,
-       the projects created by the 3rd party consumer can open and build. But the real 3rd party consumer will not
-       have run this step so they won't be able to open their projects. 
-       To ship, the project type author must create an MSI that places these files in a well-known location on the
-       customer machine and update the project template to point at that location.-->
+  <!-- This will include the msbuild files and rules files in the VSIX file, installed under 
+       MSBuildExtensionsPath ([Visual Studio Install Path]\MSBuild). This gives the files a well-known
+       location, so projects can import these files and work for different users on the same machine, or work
+       on different machines when VS is installed on a different path, as long as the VSIX was installed.
+       NOTE: The VSIX manifest needs the "This VSIX is installed for all users (requires elevation on install)"
+       checkbox to be checked. -->
+  <ItemGroup>
+    <VSIXSourceItem Include="BuildSystem\DeployedBuildSystem\**">
+      <InProject>false</InProject>
+      <InstallRoot>MSBuild</InstallRoot>
+      <VSIXSubPath>CustomProjectSystems\WindowsScript</VSIXSubPath>
+    </VSIXSourceItem>
+    <VSIXSourceItem Include="BuildSystem\Rules\**">
+      <InProject>false</InProject>
+      <InstallRoot>MSBuild</InstallRoot>
+      <VSIXSubPath>CustomProjectSystems\WindowsScript\Rules</VSIXSubPath>
+    </VSIXSourceItem>
+  </ItemGroup>
+  <!-- Although the above causes the VSIX to contain the MSBuild and rules files, the automatic deploy of the
+       VSIX to the experimental instance of Visual Studio on build does not copy the files to the MSBuild
+       location. In order to simplify development, we'll copy the files to a different well-known location. To
+       avoid needed to run Visual Studio as administrator, or overwriting the files installed by the VSIX,
+       we'll copy to a different location, in the current user's profile. However, this requires any project
+       used to test the project system to import the files from a different location than to use the project
+       system installed from the VSIX. -->
   <Target Name="AfterBuild">
     <ItemGroup>
       <BuildSystemToCopy Include="BuildSystem\DeployedBuildSystem\**\*" />

--- a/samples/WindowsScript/WindowsScript/WindowsScript.ProjectType/source.extension.vsixmanifest
+++ b/samples/WindowsScript/WindowsScript/WindowsScript.ProjectType/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="WindowsScript.ProjectType..61d255dd-a819-4936-9f07-e660d0572111" Version="1.0" Language="en-US" Publisher="WindowsScript.ProjectType" />
-    <DisplayName>Windows Script VSIX</DisplayName>
-    <Description xml:space="preserve">A template for creating a Windows Script project.</Description>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="15.0" />
-  </Installation>
-  <Dependencies>
-    <!--<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.6" />-->
-    <!--<Dependency d:Source="Installed" Id="B73A99D8-FCAA-4197-9122-F8ABA095A72F" DisplayName="Visual Studio Common Project System v14" Version="[11.2,14.0)" />-->
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="WindowsScript.ProjectType" Path="|WindowsScript.ProjectType|"/>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="WindowsScript.ProjectType" Path="|WindowsScript.ProjectType;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WindowsScript.ProjectTemplate" d:TargetPath="|WindowsScript.ProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="WindowsScript.ProjectType..61d255dd-a819-4936-9f07-e660d0572111" Version="1.0" Language="en-US" Publisher="WindowsScript.ProjectType" />
+        <DisplayName>Windows Script VSIX</DisplayName>
+        <Description xml:space="preserve">A template for creating a Windows Script project.</Description>
+    </Metadata>
+    <Installation AllUsers="true">
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="15.0" />
+    </Installation>
+    <Dependencies>
+        <!--<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.6" />-->
+        <!--<Dependency d:Source="Installed" Id="B73A99D8-FCAA-4197-9122-F8ABA095A72F" DisplayName="Visual Studio Common Project System v14" Version="[11.2,14.0)" />-->
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="WindowsScript.ProjectType" Path="|WindowsScript.ProjectType|"/>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="WindowsScript.ProjectType" Path="|WindowsScript.ProjectType;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="WindowsScript.ProjectTemplate" d:TargetPath="|WindowsScript.ProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
VSIX v3 can install files to a few locations outside the VS extensions folder, including the MSBuild extensions folder, so an MSI installer for the project system extension is not required. 

I changed the sample project to demonstrate how to get the files included in the VSIX, and I changed the sample template to import the props and targets files from the MSBuild extensions folder.