### PR TITLE
Say that static DependentUpon is evaluation-only

### DIFF
--- a/doc/extensibility/automatic_DependentUpon_wireup.md
+++ b/doc/extensibility/automatic_DependentUpon_wireup.md
@@ -6,7 +6,8 @@ In Solution Explorer, dependent items get displayed as chilren items under the i
 
 ## Static dependency
 
-The dependent information gets stored in the project file, using `<DependentUpon>` metadata.
+The dependent information gets stored in the project file, using
+evaluation-time `<DependentUpon>` metadata.
 
 ```xml
   <None Include="foo.xaml" />


### PR DESCRIPTION
Static DependentUpon wire-up can only use evaluation-time item metadata;
it cannot use execution time (e.g., changed by MSBuild targets).

Fixes https://github.com/Microsoft/VSProjectSystem/issues/274