### PR TITLE
Add link to SDK download

### DIFF
--- a/doc/extensibility/project_item_templates.md
+++ b/doc/extensibility/project_item_templates.md
@@ -1,7 +1,7 @@
 Item Templates
 ====================
 
-The Project System Extensibility SDK offers several item templates.
+The [Project System Extensibility SDK](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.VisualStudioProjectSystemExtensibilityPreview) offers several item templates.
 
 They can be easily added to your project by using Add New Item. They are located under the Visual C# Items/Extensibility/Project System Node in the Add New Item dialog.
 


### PR DESCRIPTION
It was not clear to me in reading these docs that this SDK was a separate download. I had installed the "Visual Studio extension development" toolset in the VS installer, but none of the items in these docs were showing up. It was very confusing. Hoping this link will help clarify.