### PR TITLE
Rename UnitTestContainer to TestContainer

### DIFF
--- a/doc/overview/project_capabilities.md
+++ b/doc/overview/project_capabilities.md
@@ -61,7 +61,7 @@ known to declare the capability.
 | FabricApplication | Indicates a project that represents a Service Fabric application.
 | LSJavaScript.v45 | Indicates a project that represents a LightSwitch JavaScript V4.5 project.
 | FolderPublish | Indicates a project that is capable of publishing the deployment artifacts to a folder.
-| UnitTestContainer | The project may contain unit tests. 
+| TestContainer | The project may contain unit tests. 
 | AppDesigner | Indicates that the project uses the app designer for managing project properties.
 | HandlesOwnReload | Indicates that the project can handle a reload by itself (potentially smartly) without the solution doing a full reload of the project when the project file changes on disk.
 | UseFileGlobs | Indicates that the project file can include files using MSBuild file globbing patterns.


### PR DESCRIPTION
Fixes: #328 

I think the proper naming should be `TestContainer` as it is used in `Microsoft.NET.Test.Sdk`.

https://github.com/microsoft/vstest/blob/f0cd370fa400b9e6ab220096b5a8f14a028ac4f2/src/package/nuspec/Microsoft.NET.Test.Sdk.props#L19-L21

