### PR TITLE
Fix heading formatting in IDynamicEnumValuesProvider.md

### DIFF
--- a/doc/extensibility/IDynamicEnumValuesProvider.md
+++ b/doc/extensibility/IDynamicEnumValuesProvider.md
@@ -5,7 +5,8 @@ IDynamicEnumValuesProvider
 
 Provides a dynamic list of enum values using an `IDynamicEnumValuesGenerator`. You can also provide an optional list of name value pairs when using the editor from a xaml rule (see Usage below).
 
-##IDynamicEnumValuesProvider
+## IDynamicEnumValuesProvider
+
 ```csharp
     [ExportDynamicEnumValuesProvider("DynamicEnumValues1Provider")]
     [AppliesTo("...")]
@@ -32,7 +33,9 @@ Provides a dynamic list of enum values using an `IDynamicEnumValuesGenerator`. Y
         }
     }
 ```
-##IDynamicEnumValuesGenerator
+
+## IDynamicEnumValuesGenerator
+
 ~~**Note:** Issue [#53](https://github.com/Microsoft/VSProjectSystem/issues/53)~~ (Fixed in Visual Studio 2015 Update 1)
 `AllowCustomValues` and `TryCreateEnumValueAsync` are ignored by the Project System runtime in the RTM version of Visual Studio 2015, but may be supported in future releases. The suggested implementations below attempt to match the current behavior (any value gets accepted) to minimize disruption when this feature is enabled.
 
@@ -96,7 +99,8 @@ Provides a dynamic list of enum values using an `IDynamicEnumValuesGenerator`. Y
     }
 ```
 
-###Visual Studio 2015 Update 1 Changes
+### Visual Studio 2015 Update 1 Changes
+
 `TryCreateEnumValueAsync` will be connected and is called whenever the user submits a new value to the property
 `AllowCustomValues` is now obsolete and will be removed in a future version.
 


### PR DESCRIPTION
Headings need a white space between the `#` characters and the heading text to render property on GitHub.