### PR TITLE
Fix links to blog posts

### DIFF
--- a/doc/extensibility/property_pages.md
+++ b/doc/extensibility/property_pages.md
@@ -16,8 +16,8 @@ set of such XAML rules that you can use as a model.
 
 For more details, please refer to the following blog posts:
 
-1. [Platform Extensibility part 1](https://docs.microsoft.com/en-us/visualstudio/extensibility/creating-a-basic-project-system-part-1?view=vs-2017)
-2. [Platform Extensibility part 2](https://docs.microsoft.com/en-us/visualstudio/extensibility/creating-a-basic-project-system-part-2?view=vs-2017)
+1. [Platform Extensibility part 1](https://docs.microsoft.com/archive/blogs/vsproject/platform-extensibility-part-1)
+2. [Platform Extensibility part 2](https://docs.microsoft.com/archive/blogs/vsproject/platform-extensibility-part-2)
 
 These properties get compiled into `.cs` file at build time 
 


### PR DESCRIPTION
A previous commit attempted to fix up these links to point to updated
locations on docs.microsoft.com instead of blogs.msdn.com. However, the
updated links actually pointed to unrelated documentation--with a
similar name--on creating a new project system based on MPF (the Managed
Project Framework), rather than the blog posts on creating property
pages in a CPS-based project system. This commit corrects the links.