### PR TITLE
Update example of a bad capability

### DIFF
--- a/doc/overview/about_project_capabilities.md
+++ b/doc/overview/about_project_capabilities.md
@@ -83,7 +83,7 @@ It's very important that project capabilities you define fit this criteria:
   - Bad: `Concurrency`
 - Avoid acronyms: 
   - Good: `CSharp`
-  - Bad: `VB`
+  - Bad: `CS`
 - May include a version number, when necessary, but is usually discouraged.
 
 ### Dynamic project capabilities in Visual Studio 2017


### PR DESCRIPTION
VB projects do actually use the `VB` capability. While that may not have been the best choice given this guidance, we can at least update the documentation to use an example that doesn't exist in common use.

(Pointed out by Jason Malinowski via email.)