### PR TITLE
Fix markdown formatting

### DIFF
--- a/doc/scenario/provide_custom_icons_for_the_project_or_item_type.md
+++ b/doc/scenario/provide_custom_icons_for_the_project_or_item_type.md
@@ -4,19 +4,19 @@ Provide custom icons for the Project Type/Item type
 
 **[Item template:](../extensibility/project_item_templates.md)** Custom Icons
 
-##Tutorial
+## Tutorial
 In order to add custom icons to your project, you need to follow these steps:
 
 1. Add New Item
-  - **Visual Studio 2017**: `Project Tree Properties Provider extension`
-  - **Visual Studio 2015**: `Project Tree Modifier extension`
-  - This will add an [IProjectTreePropertiesProvider](../extensibility/IProjectTreePropertiesProvider.md)/[IProjectTreeModifier](../extensibility/IProjectTreeModifier.md) export to your project type that will replace the project icon with a JavaScript Icon
+   - **Visual Studio 2017**: `Project Tree Properties Provider extension`
+   - **Visual Studio 2015**: `Project Tree Modifier extension`
+   - This will add an [IProjectTreePropertiesProvider](../extensibility/IProjectTreePropertiesProvider.md)/[IProjectTreeModifier](../extensibility/IProjectTreeModifier.md) export to your project type that will replace the project icon with a JavaScript Icon
 2. Add New Item - `Custom Icons`. This template does a few things:
-  - Generates a new .imagemanifest file, that defines one image with 2 sources:
-    - .png file that will be used for 100 % dpi
-    - .xaml file that will be used for everything else
-    - Note that `Include in VSIX` is set to true
-  - Generates a new class (`Images1Monikers.cs`) that exposes a property to easily access the new image
+   - Generates a new .imagemanifest file, that defines one image with 2 sources:
+     - .png file that will be used for 100 % dpi
+     - .xaml file that will be used for everything else
+     - Note that `Include in VSIX` is set to true
+   - Generates a new class (`Images1Monikers.cs`) that exposes a property to easily access the new image
 3. Update the file generated at step 2 to consume the ImageMoniker exposed at step 1
 
 **Visual Studio 2017:**
@@ -29,31 +29,31 @@ propertyValues.Icon = Images1Monikers.ProjectIconImageMoniker.ToProjectSystemTyp
 tree = tree.SetIcon(Images1Monikers.ProjectIconImageMoniker.ToProjectSystemType());
 ```
 
-##Adding an image manifest manually
+## Adding an image manifest manually
 1. Image manifest
    1. Create a new xml file, name it to .imagemanifest (e.g. `Images1.imagemanifest`)
   
-   ```xml
-   <?xml version="1.0" encoding="utf-8"?>
-   <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                  xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
-     <Symbols>
-       <String Name="Resources" Value="/<AssemblyName>;Component/" />
-       <Guid Name="Images1Guid" Value="<GUID>" />
-       <ID Name="ProjectIcon" Value="0" />
-     </Symbols>
-     <Images>
-       <Image Guid="$(Images1Guid)" ID="$(ProjectIcon)">
-         <Source Uri="$(Resources)/Images/Images1ProjectIcon.xaml" />
-         <Source Uri="$(Resources)/Images/Images1ProjectIcon.png" >
-           <Size Value="16" />
-         </Source>  
-       </Image>
-     </Images>
-     <ImageLists />
-   </ImageManifest>
-   ```
+      ```xml
+      <?xml version="1.0" encoding="utf-8"?>
+      <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
+        <Symbols>
+          <String Name="Resources" Value="/<AssemblyName>;Component/" />
+          <Guid Name="Images1Guid" Value="<GUID>" />
+          <ID Name="ProjectIcon" Value="0" />
+        </Symbols>
+        <Images>
+          <Image Guid="$(Images1Guid)" ID="$(ProjectIcon)">
+            <Source Uri="$(Resources)/Images/Images1ProjectIcon.xaml" />
+            <Source Uri="$(Resources)/Images/Images1ProjectIcon.png" >
+              <Size Value="16" />
+            </Source>  
+          </Image>
+        </Images>
+        <ImageLists />
+      </ImageManifest>
+      ```
    2. Replace `<AssemblyName>` with your assembly name 
    3. Replace `<GUID>`with a guid
    3. In the Properties page, set the following properties:


### PR DESCRIPTION
- Headings need a space after the `##` characters.
- Nested content within lists needs three spaces to display correctly.