### PR TITLE
Fix a using error in the CpsExtension sample

### DIFF
--- a/samples/CpsExtension/CpsExtension.Vsix/CustomDebugger.cs
+++ b/samples/CpsExtension/CpsExtension.Vsix/CustomDebugger.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Composition;
+    using System.ComponentModel.Composition;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.ProjectSystem;
     using Microsoft.VisualStudio.ProjectSystem.Debug;

--- a/samples/CpsExtension/CpsExtension.Vsix/Rules/ProjectProperties.cs
+++ b/samples/CpsExtension/CpsExtension.Vsix/Rules/ProjectProperties.cs
@@ -1,6 +1,6 @@
 namespace CpsExtension.Rules
 {
-    using System.Composition;
+    using System.ComponentModel.Composition;
     using Microsoft.VisualStudio.ProjectSystem;
     using Microsoft.VisualStudio.ProjectSystem.Properties;
 


### PR DESCRIPTION
The CpsExtension sample would fail to load for target projects because it would fail to create a instance of `CustomDebugger`. This is caused by the `ImportingConstructor` attribute, which should be `System.ComponentModel.Composition.ImportingConstructorAttribute` instead of `System.Composition.ImportingConstructorAttribute`.

With this change the extension will load without an error when opening a project that implements the nuget from the sample. After this fix, I still don't get the expected behaviour in Visual Studio as is described in the documentation of the sample, so I suspect there is something else that's broken as well.